### PR TITLE
Remove xenial series from charm.

### DIFF
--- a/charm/cert-manager/metadata.yaml
+++ b/charm/cert-manager/metadata.yaml
@@ -19,5 +19,4 @@ tags:
   - pki
 subordinate: false
 series:
-- xenial
 - bionic


### PR DESCRIPTION
xenial could be supported, but we'll standardize on bionic unless there
is some reason to deploy onto xenial.